### PR TITLE
Update error.c

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -269,6 +269,7 @@ void gumbo_error_destroy(GumboParser* parser, GumboError* error) {
 
 void gumbo_init_errors(GumboParser* parser) {
   gumbo_vector_init(parser, 5, &parser->_output->errors);
+  parser->_output->error_messages = NULL;
 }
 
 void gumbo_destroy_errors(GumboParser* parser) {


### PR DESCRIPTION
gumbo_destroy_output would crash at parser.c:4221 if error_messages is uninitialized